### PR TITLE
enable plugin multiplexing

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,11 @@ func main() {
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 
-	if err := plugin.Serve(&plugin.ServeOpts{
+	if err := plugin.ServeMultiplex(&plugin.ServeOpts{
 		BackendFactoryFunc: Factory,
-		TLSProviderFunc:    tlsProviderFunc,
+		// set the TLSProviderFunc so that the plugin maintains backwards
+		// compatibility with Vault versions that don’t support plugin AutoMTLS
+		TLSProviderFunc: tlsProviderFunc,
 	}); err != nil {
 		log.Fatal(err)
 	}
@@ -52,10 +54,10 @@ func Backend(c *logical.BackendConfig) *backend {
 			Unauthenticated: []string{"login"},
 		},
 		Paths: []*framework.Path{
-			&framework.Path{
+			{
 				Pattern: "login",
 				Fields: map[string]*framework.FieldSchema{
-					"password": &framework.FieldSchema{
+					"password": {
 						Type: framework.TypeString,
 					},
 				},


### PR DESCRIPTION
- the plugin will be multiplexed when run against vault versions that support plugin multiplexing
- we continue to set the TLSProviderFunc to maintain backwards compatibility with vault versions that don't support AutoMTLS (< 1.12)

