### PR TITLE
Indent to fix step numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,30 +20,30 @@ GitHub. Alternatively you can compile the plugin from source.
 
 1. Move the compiled plugin into Vault's configured `plugin_directory`:
 
-```sh
-$ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
-```
+  ```sh
+  $ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
+  ```
 
 1. Calculate the SHA256 of the plugin and register it in Vault's plugin catalog.
 If you are downloading the pre-compiled binary, it is highly recommended that
 you use the published checksums to verify integrity.
 
-```sh
-$ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
+  ```sh
+  $ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
 
-$ vault plugin register \
-    -sha256="${SHA256}" \
-    -command="vault-auth-plugin-example" \
-    auth example-auth-plugin
-```
+  $ vault plugin register \
+      -sha256="${SHA256}" \
+      -command="vault-auth-plugin-example" \
+      auth example-auth-plugin
+  ```
 
 1. Mount the auth method:
 
-```sh
-$ vault auth enable \
-    -path="example" \
-    -plugin-name="example-auth-plugin" plugin
-```
+  ```sh
+  $ vault auth enable \
+      -path="example" \
+      -plugin-name="example-auth-plugin" plugin
+  ```
 
 ## Authenticating with the Shared Secret
 

--- a/README.md
+++ b/README.md
@@ -20,30 +20,30 @@ GitHub. Alternatively you can compile the plugin from source.
 
 1. Move the compiled plugin into Vault's configured `plugin_directory`:
 
-  ```sh
-  $ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
-  ```
+```sh
+$ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
+```
 
 1. Calculate the SHA256 of the plugin and register it in Vault's plugin catalog.
 If you are downloading the pre-compiled binary, it is highly recommended that
 you use the published checksums to verify integrity.
 
-  ```sh
-  $ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
+```sh
+$ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
 
-  $ vault plugin register \
-      -sha256="${SHA256}" \
-      -command="vault-auth-plugin-example" \
-      auth example-auth-plugin
-  ```
+$ vault plugin register \
+    -sha256="${SHA256}" \
+    -command="vault-auth-plugin-example" \
+    auth example-auth-plugin
+```
 
 1. Mount the auth method:
 
-  ```sh
-  $ vault auth enable \
-      -path="example" \
-      -plugin-name="example-auth-plugin" plugin
-  ```
+```sh
+$ vault auth enable \
+    -path="example" \
+    -plugin-name="example-auth-plugin" plugin
+```
 
 ## Authenticating with the Shared Secret
 

--- a/README.md
+++ b/README.md
@@ -20,30 +20,30 @@ GitHub. Alternatively you can compile the plugin from source.
 
 1. Move the compiled plugin into Vault's configured `plugin_directory`:
 
-  ```sh
-  $ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
-  ```
+    ```sh
+    $ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
+    ```
 
 1. Calculate the SHA256 of the plugin and register it in Vault's plugin catalog.
 If you are downloading the pre-compiled binary, it is highly recommended that
 you use the published checksums to verify integrity.
 
-  ```sh
-  $ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
+    ```sh
+    $ export SHA256=$(shasum -a 256 "/etc/vault/plugins/vault-auth-plugin-example" | cut -d' ' -f1)
 
-  $ vault plugin register \
-      -sha256="${SHA256}" \
-      -command="vault-auth-plugin-example" \
-      auth example-auth-plugin
-  ```
+    $ vault plugin register \
+        -sha256="${SHA256}" \
+        -command="vault-auth-plugin-example" \
+        auth example-auth-plugin
+    ```
 
 1. Mount the auth method:
 
-  ```sh
-  $ vault auth enable \
-      -path="example" \
-      -plugin-name="example-auth-plugin" plugin
-  ```
+    ```sh
+    $ vault auth enable \
+        -path="example" \
+        -plugin-name="example-auth-plugin" plugin
+    ```
 
 ## Authenticating with the Shared Secret
 


### PR DESCRIPTION
# Overview
This fixes an issue in the README where the step numbers reset after a code block.

# Design of Change
Added additional two spaces to the indentation of code blocks in the README [as described on SO](https://stackoverflow.com/a/22138846).

# Related Issues/Pull Requests
[Issue #26](https://github.com/hashicorp/vault-auth-plugin-example/issues/26)

# Contributor Checklist
This is just a README update
