### PR TITLE
Warning for MacOS etc symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ GitHub. Alternatively you can compile the plugin from source.
   ```sh
   $ mv vault-auth-plugin-example /etc/vault/plugins/vault-auth-plugin-example
   ```
+  Note that on MacOS, the etc directory is a symlink. Vault does not allow symlink directories for plugins.
 
 1. Calculate the SHA256 of the plugin and register it in Vault's plugin catalog.
 If you are downloading the pre-compiled binary, it is highly recommended that


### PR DESCRIPTION
# Overview
This updates the README with a warning regarding /etc/ being a symlink on MacOS as that can be a pitfall for someone following the tutorial on Mac.

Considered other approaches such as being more prescriptive with the steps of the Vault setup. Happy to redo if another approach is in mind.

# Design of Change
It is a one-line addition to the README to warn users.

# Related Issues/Pull Requests
[Issue #25](https://github.com/hashicorp/vault-auth-plugin-example/issues/25)
Will require a minor update if [PR #27](https://github.com/hashicorp/vault-auth-plugin-example/pull/27) is merged.

# Contributor Checklist
README update