### PR TITLE
chore: add errcheck for parsing cli flags

### DIFF
--- a/cmd/vault-auth-plugin-example/main.go
+++ b/cmd/vault-auth-plugin-example/main.go
@@ -22,7 +22,10 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags. If `flag.Parse()` fails now the error is hidden from the user.

# Design of Change

An error check was missing and I added it 👍 

# Related Issues/Pull Requests

Originally noticed at https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202

# Contributor Checklist
[-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
Not needed

[-] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
Not needed

[x] Backwards compatible
